### PR TITLE
Apply better optimization levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 OPTS      := -DDO_COUNT -DTEXT_REPLY -DREAD_FILE -DREAD_GIF -DNULLSERV_REPLIES -DSSL_RESP
 TEST_OPTS := -DTEST -DVERBOSE
-TINY_OPTS := -O3 -DTINY
+TINY_OPTS := -Os -DTINY
 DEBUG_OPT := -DHEX_DUMP
 CC        := gcc
-CFLAGS    += -Os -s -Wall -ffunction-sections -fdata-sections -fno-strict-aliasing
+CFLAGS    += -O2 -s -Wall -ffunction-sections -fdata-sections -fno-strict-aliasing
 LDFLAGS   += -Wl,--gc-sections
 STRIP     := strip -s -R .note -R .comment -R .gnu.version -R .gnu.version_r
 CROSSCC   := mipsel-uclibc-gcc


### PR DESCRIPTION
We should optimize for size our binary if we're targeting for smallest binary size, and we should optimize for speed our binary if size doesn't matter that much.

root@ArchiDroid:~/git/cc/pixelserv# $CC -O3 -DTINY pixelserv.c -o O3
root@ArchiDroid:~/git/cc/pixelserv# $CC -Os -DTINY pixelserv.c -o Os
root@ArchiDroid:~/git/cc/pixelserv# ls -l O*
-rwxr-xr-x 1 root root 11268 kwi 20 19:18 O3
-rwxr-xr-x 1 root root 11256 kwi 20 19:18 Os

O3 gives up to ~50% bigger binary compared to O2, while it doesn't offer any noticable improvement. In fact, O2 usually gives smaller and faster binary in comparision with O3, mostly due to CPU cache. IMHO it's a better idea to use O2 by default.

When compiling as TINY, output effect of O2 and O3 doesn't even differ:

root@ArchiDroid:~/git/cc/pixelserv# $CC -O3 -DTINY pixelserv.c -o O3
root@ArchiDroid:~/git/cc/pixelserv# $CC -O2 -DTINY pixelserv.c -o O2
root@ArchiDroid:~/git/cc/pixelserv# md5sum O2
c74c165eabb111bc3922d98bc61eb28a  O2
root@ArchiDroid:~/git/cc/pixelserv# md5sum O3
c74c165eabb111bc3922d98bc61eb28a  O3

When using standard OPTS, it does, but the size is the same:

root@ArchiDroid:~/git/cc/pixelserv# $CC -O2 -DDO_COUNT -DTEXT_REPLY -DREAD_FILE -DREAD_GIF -DNULLSERV_REPLIES -DSSL_RESP pixelserv.c -o O2
root@ArchiDroid:~/git/cc/pixelserv# $CC -O3 -DDO_COUNT -DTEXT_REPLY -DREAD_FILE -DREAD_GIF -DNULLSERV_REPLIES -DSSL_RESP pixelserv.c -o O3
root@ArchiDroid:~/git/cc/pixelserv# ls -l O*
-rwxr-xr-x 1 root root 17008 kwi 20 19:24 O2
-rwxr-xr-x 1 root root 17008 kwi 20 19:25 O3

Therefore, we should use Os for TINY, and O2 for the rest.
